### PR TITLE
🐛 페이지 경로 체크 기능 추가 / 페이지 이동시의 오류 문제 해결

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,14 @@
             <h1>Home 화면</h1>
             <nav>
                 <br>
-                <p><a class="text_red" href="/html/api_test.html"> > API 테스트용 링크로 이동</a></p>
-                <p><a class="text_red" href="/html/style_guide.html"> > 페이지로 이동 - 스타일 가이드 (미적용)</a></p>
+                <!-- <p><a class="text_red" href="/html/api_test.html"> > API 테스트용 링크로 이동</a></p> -->
+                <!-- <p><a class="text_red" href="/html/style_guide.html"> > 페이지로 이동 - 스타일 가이드 (미적용)</a></p> -->
                 <!-- <p><a class="text_red" href="/html/blank.html"> > 페이지로 이동 - blank 템플릿</a></p> -->
                 <br>
                 <p><a class="text_seagreen" href="html/search_result.html"> > 페이지로 이동 - 상세 검색</a></p>
                 <p><a class="text_seagreen" href="html/item_detail.html"> > 페이지로 이동 - 도서 상세 정보</a></p>
                 <br>
-                <p><a class="text_seagreen" href="/html/list_shopping.html"> > 페이지로 이동 - 장바구니</a></p>
+                <!-- <p><a class="text_seagreen" href="/html/list_shopping.html"> > 페이지로 이동 - 장바구니</a></p> -->
                 <p><a class="text_seagreen" href="/html/purchase.html"> > 페이지로 이동 - 구매 진행</a></p>
                 <br>
                 <p><a class="text_seagreen" href="html/info_shop.html"> > 페이지로 이동 - 매장안내 </a></p>

--- a/script/main.js
+++ b/script/main.js
@@ -117,6 +117,8 @@ let callback = [];
 
 let data = '';
 
+// ! html control (object)
+
 // * HOME 슬라이드 관련 변수
 let slides = document.querySelector('.slides');
 
@@ -132,7 +134,7 @@ let prevBtn = document.querySelector('.prev');
 
 let nextBtn = document.querySelector('.next');
 
-// ! html control (object)
+const pathNow = window.location.pathname; // ! 현재 윈도우의 경로 체크용
 
 // * -------------
 // * 함수 영역 -일반
@@ -384,8 +386,13 @@ const moveSlide = (num) => {
     }
 };
 
-prevBtn.addEventListener('click', () => moveSlide(currentIdx - 1));
-nextBtn.addEventListener('click', () => moveSlide(currentIdx + 1));
+// ? addEventListener를 함수로 감싸 특정 페이지에서만 호출하여 사용 (최하단 확인)
+// ! 페이지 이동시 해당 요소를 찾지 못한 addEventListner로 인해 에러 출력되는 문제 해결용
+
+const slideControlSetup = () => {
+    prevBtn.addEventListener('click', () => moveSlide(currentIdx - 1));
+    nextBtn.addEventListener('click', () => moveSlide(currentIdx + 1));
+};
 
 // * -------------
 // * 테스트 코드 영역
@@ -437,6 +444,19 @@ const getListByKeyword = () => {
 // * -------------
 // ! 페이지 로드 후 실행이 필요한 기능
 
-loadSlideBooks();
-renderReviews(); // 리뷰 렌더링
+if (pathNow === '/index.html' || pathNow === '/') {
+    slideControlSetup();
+    loadSlideBooks();
+} else if (pathNow === '/html/item_detail.html') {
+    renderReviews(); // 리뷰 렌더링
+} else if (pathNow === '/html/search_result.html') {
+    console.log(pathNow);
+} else if (pathNow === '/html/purchase.html') {
+    console.log(pathNow);
+} else if (pathNow === '/html/info_shop.html') {
+    console.log(pathNow);
+} else {
+    console.log('해당 페이지에 대한 렌더링 함수가 없습니다.');
+}
+
 console.log('start-update');


### PR DESCRIPTION
main.js 하단 실행 영역에 각각의 페이지를 분기하여 필요한 함수만 실행할 수 있도록 수정해두었습니다.

하영님 슬라이드 버튼의 addEventListener도 함수로 감싸 위의 방법으로 다른 페이지에서 에러가 뜨지 않도록 처리했습니다.

다른 분들도 참고하시어 내 코드가 다른 페이지에 에러를 내지 않도록 해주세요.