### PR TITLE
✨ 로컬스토리지를 이용한 페이지 전환시 데이터 공유 기능 추가

### DIFF
--- a/html/item_detail.html
+++ b/html/item_detail.html
@@ -8,7 +8,9 @@
 </head>
 
 <body>
-    <p><a class="text_red" href="/index.html"> > Home으로 돌아가기</a></p>
+  <header>
+    <h1><a href="/index.html">Noona Books</a></h1>
+  </header>
     <main class="page_item_detail">
         <h1>Aladin 상품 조회</h1>
         <button onclick="getItemDetails()">상품 상세 정보 조회</button>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 <!-- <p><a class="text_red" href="/html/blank.html"> > 페이지로 이동 - blank 템플릿</a></p> -->
                 <!-- <br> -->
                 <!-- <p><a class="text_seagreen" href="html/search_result.html"> > 페이지로 이동 - 상세 검색</a></p> -->
-                <p><a class="text_seagreen" href="html/item_detail.html"> > 페이지로 이동 - 도서 상세 정보</a></p>
+                <p><a class="text_seagreen" id="btnItemDetail"> > 페이지로 이동 - 도서 상세 정보</a></p>
                 <br>
                 <!-- <p><a class="text_seagreen" href="/html/list_shopping.html"> > 페이지로 이동 - 장바구니</a></p> -->
                 <p><a class="text_seagreen" href="/html/purchase.html"> > 페이지로 이동 - 구매 진행</a></p>
@@ -32,7 +32,7 @@
 
         <article>
             <!-- ? 하영 빠른 검색 -->
-            <div class="home_easy_search">
+            <div class="home_easy_search" id="main_anchor_1">
                 <input type="text" class="easy_input" id="easy_keyword" placeholder="검색어를 입력해주세요.">
                 <button class="search_btn" id="easy_search_btn" onclick="easySearchBooks()"><svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="40" height="40" viewBox="0 0 50 50">
                     <path d="M 21 3 C 11.621094 3 4 10.621094 4 20 C 4 29.378906 11.621094 37 21 37 C 24.710938 37 28.140625 35.804688 30.9375 33.78125 L 44.09375 46.90625 L 46.90625 44.09375 L 33.90625 31.0625 C 36.460938 28.085938 38 24.222656 38 20 C 38 10.621094 30.378906 3 21 3 Z M 21 5 C 29.296875 5 36 11.703125 36 20 C 36 28.296875 29.296875 35 21 35 C 12.703125 35 6 28.296875 6 20 C 6 11.703125 12.703125 5 21 5 Z"></path>
@@ -42,7 +42,7 @@
 
             <!-- ? 하영님 추천도서 슬라이드 -->
             <div class="home_proto">
-                <h1 id="main_anchor_1" class="main_recommend">추천도서</h1>
+                <h1 class="main_recommend">추천도서</h1>
                 <div class="slide_wrapper">
                     <div class="slides" id="main_slide"></div>
                 </div>
@@ -73,13 +73,12 @@
                             <p class="text_cyon text_50">"자네는 꼭 이 글을 써야하네!"</p>
                         </div>
                     </div>
-                    <div class="editor_img"><img src="/img/editor_01.jpg" alt=""></div>
+                    <div class="editor_img" id="linkOutEditor"><img src="/img/editor_01.jpg" alt=""></div>
                 </div>
             </div>
             <div id="main_anchor_3" class="main_test">
-                <p>테스트를 위한 더미 영역입니다.</p>
+                <p>(예정)신간 알림</p>
             </div>
-
 
         </article>
 

--- a/script/main.js
+++ b/script/main.js
@@ -119,9 +119,17 @@ let callback = [];
 
 let data = '';
 
+let testISBN13 = 999;
+
+let testStorageRequest = {
+    type: 'ISBN13',
+    ISBN13: 888,
+    ID: 777,
+};
+
 // ! html control (object)
 
-// * HOME 슬라이드 관련 변수
+// ? HOME 슬라이드 관련 변수
 let slides = document.querySelector('.slides');
 
 let slideItem = document.querySelectorAll('.slides .slide_item');
@@ -136,7 +144,12 @@ let prevBtn = document.querySelector('.prev');
 
 let nextBtn = document.querySelector('.next');
 
-const pathNow = window.location.pathname; // ! 현재 윈도우의 경로 체크용
+// ? 현재 윈도우의 경로 체크용
+const pathNow = window.location.pathname;
+
+// ? 에디터 추천 페이지의 이미지 링크 버튼
+const linkOutEditor = document.getElementById('linkOutEditor');
+const btnItemDetail = document.getElementById('btnItemDetail');
 
 // * -------------
 // * 함수 영역 -일반
@@ -166,6 +179,8 @@ const getList = async () => {
 const getItemDetails = async (isbn13 = ItemLookUp_ItemId) => {
     let urlDetail = new URL(`https://${urlAPI_ItemLookUp}?ttbkey=${ttbKey_LUNA}`);
     console.log('get item details');
+
+    // console.log("getItemDetails - isbn13",isbn13);
 
     let ItemLookUp_ItemId = isbn13;
 
@@ -431,6 +446,71 @@ const slideControlSetup = () => {
     nextBtn.addEventListener('click', () => moveSlide(currentIdx + 1));
 };
 
+// ? 링크 아웃 관련 실행 함수
+const linkOutDirectSetup = () => {
+    btnItemDetail.addEventListener('click', () => {
+        storageTossData();
+        linkOut();
+    });
+};
+
+// ?
+const linkOutEditorSetup = () => {
+    linkOutEditor.addEventListener('click', () => {
+        // console.log(testStorageRequest);
+        // console.log(testStorageRequest.ISBN13);
+        // storageTossData(); // ! 정보없이 새로운 페이지를 호출하기만 하는 경우
+        storageTossData(9791197956850);
+        linkOut();
+        // linkOut('/html/item_detail.html'); // ! 상세 페이지가 많이 쓰이므로 기본 매개변수로 설정함
+        // linkOut('/html/purchase.html'); // ! 구매페이지 연결시 테스트용
+        // window.location.href = 'html/item_detail.html'; //! 직접 보내는 대신 linkOut 함수 이용
+    });
+};
+
+// ? 원하는 주소로 linkOut 하기 위한 함수. 기본 주소는 상세 페이지
+
+const linkOut = (href = '/html/item_detail.html') => {
+    window.location.href = href;
+};
+
+// ? localStorage에 ISBN이나 ID값을 저장하는 함수
+
+const storageTossData = (tossData = '', tossType = 'ISBN13') => {
+    console.log('tossdata in storageTossData', '');
+    if (tossData == '') {
+        console.log('저장할 tossData가 없습니다. 기존 저장된 내용을 초기화 합니다.');
+        // testStorageRequest.type = '';
+        testStorageRequest.ISBN13 = tossData;
+        testStorageRequest.ID = tossData;
+        console.log(testStorageRequest);
+    } else {
+        testStorageRequest.type = tossType;
+        if ((tossType = 'ISBN13')) {
+            testStorageRequest.ISBN13 = tossData;
+        } else if ((tossType = 'ID')) {
+            testStorageRequest.ID = tossData;
+        } else {
+            console.log('타입에러');
+            return;
+        }
+        // console.log('sss', testStorageRequest);
+        const testObjString = JSON.stringify(testStorageRequest);
+        window.localStorage.setItem('testData', testObjString);
+        // console.log('testData 로컬저장 완료');
+    }
+};
+
+// ? localStorage에 저장된 tossData를 불러와서 반환하는 함수
+
+const unpackTossData = () => {
+    const tempTestData = window.localStorage.getItem('testData');
+    const tempTestObj = JSON.parse(tempTestData);
+    // console.log('testData 불러오기 완료', tempTestObj);
+    // console.log('testData 불러오기 완료222', tempTestObj.ISBN13);
+    return tempTestObj.ISBN13;
+};
+
 // ! 구매 페이지 (상세 페이지쪽과 상의 필요)
 // 알라딘 API에서 받아올 상품 번호 임시 데이터
 
@@ -525,8 +605,14 @@ const getListByKeyword = () => {
 
 if (pathNow === '/index.html' || pathNow === '/') {
     slideControlSetup();
+    linkOutDirectSetup();
+    linkOutEditorSetup();
     loadSlideBooks();
 } else if (pathNow === '/html/item_detail.html') {
+    console.log('check-default-testISBN13', testISBN13);
+    testISBN13 = unpackTossData();
+    console.log('unpack-ISBN13', testISBN13);
+    getItemDetails(testISBN13);
     renderReviews(); // 리뷰 렌더링
 } else if (pathNow === '/html/search_result.html') {
     console.log(pathNow);


### PR DESCRIPTION
다음의 기능들을 1차 구현했습니다.
아직 코드와 변수명이 최종 버전은 아니지만, 테스트는 문제 없이 가능하여 풀리퀘스트 올립니다.
editor's choice 에서 책 이미지를 클릭하시면 작동 확인해보실 수 있습니다.

- 테스트를 위해 상세 페이지가 바로 랜더링 되는 기능을 추가했습니다.

1) 함수 - linkOut()
- 원하는 주소로 이동하는 간단한 함수입니다.
- 매개변수 (url) - 주소를 넣으면 실행시 해당 주소로 이동합니다.
- 매개변수에 url 정보를 입력하지 않으면 이동하는 기본값은 제품 상세 페이지입니다.

2) 함수 - storageTossData()
- 로컬 스토리지에 토스할 데이터를 저장합니다.
- 매개변수 (data, type)
  data = 원하는 값을 넣습니다.
  type (option) = 아무것도 넣지 않거나 ISBN13을 넣으면 ISBN13값을 바꿉니다. / ID를 넣으면 대신 ID에 값을 넣습니다.
- 매개변수에 값이 없으면 데이터를 초기화합니다. isbn과 id에 '' 값을 넣게 됩니다.

3) 함수 - unpackTossData()
- 로컬 스토리지에 저장해둔 데이터를 가져옵니다.
- return 값으로 가져온 값을 반환합니다.

------------------
실제 사용은 index 페이지의 
1) 상단에 있는 상품 상세 정보 조회 바로 가기 클릭 기능에 반영된 케이스와

관련 함수 - linkOutDirectSetup()

2) editor's choice의 세속의 철학자들 책 이미지 클릭에 반영된 케이스로 확인해 보실 수 있습니다.

관련 함수 -  linkOutEditorSetup()
